### PR TITLE
feat: control the widgets included in the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The next properties are NOT used by `cy.runExample` but are used by the `testExa
 
 - `skip` creates a skipped test with `it.skip`
 - `only` creates an exclusive test with `it.only`
+- `order` controls which widgets are shown in the map: 'test', 'html', 'live'
 
 ### Included scripts
 

--- a/cypress/integration/examples.js
+++ b/cypress/integration/examples.js
@@ -140,7 +140,6 @@ export default {
       `,
     },
     'exact then inexact matches using jQuery and cypress-pipe': {
-      only: true,
       html: source`
         <div id="example">
           <div id="inexact">my item</div>

--- a/cypress/integration/examples.js
+++ b/cypress/integration/examples.js
@@ -10,7 +10,7 @@ export default {
         `,
         test: source`
           cy.get('#my-element')
-        `
+        `,
       },
       '.get().contains()': {
         skip: true,
@@ -30,7 +30,7 @@ export default {
           // because it only checks the first two LI elements
           // over and over - not noticing the 3rd LI
           cy.get('li').contains('third')
-        `
+        `,
       },
       '.get().should("contain")': {
         only: false,
@@ -47,7 +47,7 @@ export default {
             window.document.querySelector('ul').appendChild(newLi)
           }, 2000)
           cy.get('li').should('contain', 'third')
-        `
+        `,
       },
       '.get class selector by partial text': {
         only: false,
@@ -58,8 +58,8 @@ export default {
         test: source`
           cy.get('[class*=footer]').should('have.text', 'Footer')
             .and('have.class', 'small')
-        `
-      }
+        `,
+      },
     },
     'select input by label': {
       html: source`
@@ -79,7 +79,7 @@ export default {
         // select first the label by text
         inputByLabelText('My Text')
           .should('be.visible')
-      `
+      `,
     },
     'select input by label using custom command': {
       html: source`
@@ -94,7 +94,7 @@ export default {
         )
         cy.inputByLabelText('My Text')
           .should('be.visible')
-      `
+      `,
     },
     'within row scope': {
       html: source`
@@ -115,7 +115,7 @@ export default {
           cy.get('td').eq(3).should('contain', 'Active')
           cy.get('td').eq(4).should('contain', 'Edit').find('button').click()
         })
-      `
+      `,
     },
     'within row scope using contains': {
       html: source`
@@ -137,9 +137,10 @@ export default {
           cy.get('td').eq(3).contains('Active')
           cy.get('td').eq(4).contains('button', 'Edit').click()
         })
-      `
+      `,
     },
     'exact then inexact matches using jQuery and cypress-pipe': {
+      only: true,
       html: source`
         <div id="example">
           <div id="inexact">my item</div>
@@ -174,7 +175,7 @@ export default {
 
         containsExactThenInexactText('item').should('have.attr', 'id', 'exact')
         containsExactThenInexactText('my').should('have.attr', 'id', 'inexact')
-      `
+      `,
     },
     'contains exact label match': {
       html: source`
@@ -190,7 +191,7 @@ export default {
       test: source`
         cy.contains('label', /^Default rate$/)
           .should('have.attr', 'for', 'client_default_rate')
-      `
+      `,
     },
     'single a': {
       only: false,
@@ -200,7 +201,7 @@ export default {
       test: source`
         // yields "a"
         cy.get('a').should('have.id', 'single')
-      `
+      `,
     },
     'escapes tag': {
       only: false,
@@ -210,7 +211,7 @@ export default {
       test: source`
         // yields <a>...</a>
         cy.get('a').should('have.id', 'single')
-      `
+      `,
     },
     'several classes': {
       only: false,
@@ -222,7 +223,7 @@ export default {
       `,
       test: source`
         cy.get('.one.two.three.four').should('have.text', 'correct element')
-      `
+      `,
     },
     'button title attribute': {
       only: false,
@@ -237,7 +238,7 @@ export default {
         cy.get('button.btn-danger')     // gets button that satisfies next assertion
           .should('have.attr', 'title') // yields title attribute string
           .should('match', /^1123bad:/) // checks title
-      `
-    }
-  }
+      `,
+    },
+  },
 }

--- a/cypress/integration/order-spec.js
+++ b/cypress/integration/order-spec.js
@@ -1,0 +1,44 @@
+import { source } from 'common-tags'
+import { testExamples } from '../..'
+
+const testAndLive = {
+  name: 'custom order of components',
+  html: source`
+    <ul>
+      <li data-cy="name">Bob</li>
+      <li data-cy="name">Chris</li>
+    </ul>
+  `,
+  test: source`
+    // our application "fetches" data and changes the first item
+    // from "Bob" to "Alice"
+    setTimeout(() => {
+      // simulate async change
+      document.querySelector('li[data-cy=name]').innerText = 'Alice'
+    }, 1000)
+
+    // this retries until first item changes its text to "Alice"
+    cy.contains('li[data-cy=name]:first', 'Alice')
+  `,
+  // show the test source followed by the live HTML
+  // skip the title and the HTML source
+  order: ['test', 'live'],
+}
+
+const justTest = {
+  name: 'Just the test code',
+  test: source`
+    cy.wrap(1).should('equal', 1)
+  `,
+  order: ['test'],
+}
+
+const justHTML = {
+  name: 'Just HTML and live app',
+  html: '<div>Hello</div>',
+  test: '',
+  order: ['html', 'live'],
+  only: false,
+}
+
+testExamples([testAndLive, justTest, justHTML])

--- a/cypress/integration/with-markdown-spec.js
+++ b/cypress/integration/with-markdown-spec.js
@@ -1,14 +1,15 @@
 /// <reference types="../.." />
+import { source } from 'common-tags'
 
 const test = {
   description:
     'This **test** has _markdown_, thanks to [safe-marked](+https://github.com/azu/safe-marked)',
-  html: `
-    <div>Hello</div>
+  html: source`
+    <div id="greeting">Hello</div>
   `,
-  test: `
-    cy.get('div').should('have.text', 'Hello')
-  `
+  test: source`
+    cy.get('div#greeting').should('have.text', 'Hello')
+  `,
 }
 
 it('test with markdown', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@
 
 type HTML = string
 type JavaScript = string
+type FiddleComponent = 'html' | 'live' | 'test'
 
 /**
  * Options for creating a single test fiddle.
@@ -22,7 +23,7 @@ type JavaScript = string
   ```
  */
 interface RunExampleOptions {
-  name?: string,
+  name?: string
 
   /**
    * Optional description of the test. Supports Markdown via `nmd`
@@ -32,12 +33,14 @@ interface RunExampleOptions {
    * @memberof RunExampleOptions
    * @see https://github.com/Holixus/nano-markdown
    */
-  description?: string,
-  html?: HTML,
-  test: JavaScript,
+  description?: string
+  html?: HTML
+  commonHtml?: HTML
+  test: JavaScript
   // skip and only are exclusive - they cannot be both set to true
-  skip?: boolean,
+  skip?: boolean
   only?: boolean
+  order?: FiddleComponent[]
 }
 
 declare namespace Cypress {

--- a/src/index.js
+++ b/src/index.js
@@ -60,21 +60,21 @@ Cypress.Commands.add('runExample', (options) => {
     if (html) {
       if (order.includes('html')) {
         htmlSection = `
-        <h2>HTML</h2>
-        <div id="html">
-          <pre><code class="html">${Cypress._.escape(html)}</code></pre>
-        </div>
-      `
+          <h2>HTML</h2>
+          <div id="html">
+            <pre><code class="html">${Cypress._.escape(html)}</code></pre>
+          </div>
+        `
       }
       if (order.includes('live')) {
-        htmlSection += `
-        <h2>Live HTML</h2>
-        <div id="live">
-          <div id="live-html">
+        htmlSection +=
+          '\n' +
+          `
+          <h2>Live HTML</h2>
+          <div id="live">
             ${fullLiveHtml}
           </div>
-        </div>
-      `
+        `
       }
     } else {
       htmlSection = '<div id="live"></div>'


### PR DESCRIPTION
for example, to include just the test code and the live HTML use 

```js
order: ['test', 'live']
```

closes #3