### PR TITLE
feat: add meta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The rest of the properties are optional
 - `name` the name to display at the top of the page, otherwise the test title will be used
 - `description` extra test description under the name, supports Markdown via [safe-marked](https://github.com/azu/safe-marked)
 - `commonHtml` is extra HTML markup to attach to the live HTML (if any) element. Useful for loading external stylesheets or styles without cluttering every HTML block
+- `meta` lets you include additional meta tags into the `<HEAD>` element of the page
+- `fullDocument` lets you avoid limiting your test commands to be within the mounted live HTML
 
 The next properties are NOT used by `cy.runExample` but are used by the `testExamples` function from this package.
 

--- a/cypress/integration/meta.js
+++ b/cypress/integration/meta.js
@@ -1,0 +1,22 @@
+/// <reference types="../.." />
+
+import { source } from 'common-tags'
+
+it('adds meta tags', function () {
+  const meta = source`
+    <meta name="author" content="Gleb Bahmutov">
+  `
+
+  const test = source`
+    cy.get('head')
+    cy.get('meta').should('have.length.greaterThan', 0)
+    cy.get('head meta[charset]').should('have.attr', 'charset', 'UTF-8')
+    cy.get('head meta[name=author]').should('have.prop', 'content').should('include', 'Gleb')
+  `
+
+  // because we pass the meta tags, we want to
+  // find them from the entire page
+  const fullDocument = true
+
+  cy.runExample({ meta, test, fullDocument })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "export-fiddle": "bin/export-fiddle.js"
       },
       "devDependencies": {
-        "cypress": "9.4.1",
+        "cypress": "9.7.0",
         "cypress-expect": "2.2.1",
         "cypress-pipe": "1.7.0",
         "prettier": "2.2.1",
@@ -3721,9 +3721,9 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/cypress": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.4.1.tgz",
-      "integrity": "sha512-+JgMG9uT+QFx97JU9kOHE3jO3+0UdkQ9H1oCBiC7A74qme7Jkdy2sYDBCPjjGczutnWnGUTMRlwiNMP/Uq6LrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3759,7 +3759,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -7071,9 +7071,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -15748,9 +15748,9 @@
       }
     },
     "cypress": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.4.1.tgz",
-      "integrity": "sha512-+JgMG9uT+QFx97JU9kOHE3jO3+0UdkQ9H1oCBiC7A74qme7Jkdy2sYDBCPjjGczutnWnGUTMRlwiNMP/Uq6LrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -15785,7 +15785,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -18266,9 +18266,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "9.4.1",
+    "cypress": "9.7.0",
     "cypress-expect": "2.2.1",
     "cypress-pipe": "1.7.0",
     "prettier": "2.2.1",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,6 +34,7 @@ interface RunExampleOptions {
    * @see https://github.com/Holixus/nano-markdown
    */
   description?: string
+  meta?: string
   html?: HTML
   commonHtml?: HTML
   test: JavaScript
@@ -41,6 +42,13 @@ interface RunExampleOptions {
   skip?: boolean
   only?: boolean
   order?: FiddleComponent[]
+  /**
+   * Sometimes we want to mount the "full" html and give our
+   * test access to the HEAD element. This flag is set to false
+   * by default to limit the Cypress commands to act within the live
+   * HTML block only. By setting to true you get the entire playground.
+   */
+  fullDocument?: boolean
 }
 
 declare namespace Cypress {


### PR DESCRIPTION
added `meta` options to add meta strings to the HEAD element

```
meta: '<meta name="author" content="Gleb Bahmutov">'
```

added `fullDocument: true` option (false by default) to skip limiting the querying commands to within the live html