### PR TITLE
feat: allow multiple HTML code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,23 @@ describe('Top', () => {
 })
 ```
 
+### Multiple HTML fragments
+
+You can pass multiple HTML blocks via an array
+
+    // single html code block
+    {
+      html: '<div id="greeting">Hello</div>'
+    }
+    // multiple html code blocks
+    // are concatenated
+    {
+      html: [
+        '<div id="greeting">Hello</div>',
+        '<div id="name">World</div>'
+      ]
+    }
+
 ### Live HTML
 
 You can include "live" html blocks in the fiddle - in that case they will become the test fragment.

--- a/cypress/integration/multiple-html-spec.js
+++ b/cypress/integration/multiple-html-spec.js
@@ -1,0 +1,22 @@
+/// <reference types="../.." />
+import { source } from 'common-tags'
+
+const test = {
+  description: 'This test has multiple HTML blocks',
+  html: [
+    source`
+      <div id="greeting">Hello</div>
+    `,
+    source`
+      <div id="name">World</div>
+    `,
+  ],
+  test: source`
+    cy.get('div#greeting').should('have.text', 'Hello')
+    cy.get('div#name').should('have.text', 'World')
+  `,
+}
+
+it('test with markdown', () => {
+  cy.runExample(test)
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 type HTML = string
+type HTMLS = HTML[]
 type JavaScript = string
 type FiddleComponent = 'html' | 'live' | 'test'
 
@@ -35,7 +36,7 @@ interface RunExampleOptions {
    */
   description?: string
   meta?: string
-  html?: HTML
+  html?: HTML | HTMLS
   commonHtml?: HTML
   test: JavaScript
   // skip and only are exclusive - they cannot be both set to true

--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,9 @@ const { createMarkdown } = require('safe-marked')
 const markdown = createMarkdown()
 
 Cypress.Commands.add('runExample', (options) => {
-  const {
-    name,
-    description,
-    meta,
-    commonHtml,
-    html,
-    test,
-    fullDocument,
-  } = options
+  const { name, description, meta, commonHtml, test, fullDocument } = options
+  let { html } = options
+
   // the components to include on the page
   const order = options.order || ['test', 'html', 'live']
   const testTitle =
@@ -23,6 +17,16 @@ Cypress.Commands.add('runExample', (options) => {
 
   if (typeof test !== 'string' || !test) {
     expect(test, 'must have test source').to.be.a('string')
+  }
+
+  if (typeof html === 'string') {
+    // the user specified HTML block
+  } else if (Array.isArray(html)) {
+    let combinedHtml = ''
+    html.forEach((htmlPart) => {
+      combinedHtml += htmlPart + '\n'
+    })
+    html = combinedHtml
   }
 
   const fullLiveHtml = commonHtml ? commonHtml + '\n' + html : html


### PR DESCRIPTION
You can pass multiple HTML blocks via an array

    // single html code block
    {
      html: '<div id="greeting">Hello</div>'
    }
    // multiple html code blocks
    // are concatenated
    {
      html: [
        '<div id="greeting">Hello</div>',
        '<div id="name">World</div>'
      ]
    }