### PR TITLE
feat: allow hiding HTML fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,24 @@ You can pass multiple HTML blocks via an array
       ]
     }
 
+### Hide HTML fragment
+
+You can hide an HTML fragment to avoid including it in the HTML source shown on the page. The hidden HTML is still included in the live HTML block. Each code block must be an object with the `source` property and `hide: true|false` property.
+
+    html: [
+      source`
+        <div id="greeting">Hello</div>
+      `,
+      {
+        source: source`
+          <div id="name">World</div>
+        `,
+        // do not show the source code this html block
+        // but still include it in the live html app
+        hide: true,
+      },
+    ]
+
 ### Live HTML
 
 You can include "live" html blocks in the fiddle - in that case they will become the test fragment.

--- a/cypress/integration/multiple-html-spec.js
+++ b/cypress/integration/multiple-html-spec.js
@@ -1,22 +1,51 @@
 /// <reference types="../.." />
 import { source } from 'common-tags'
 
-const test = {
-  description: 'This test has multiple HTML blocks',
-  html: [
-    source`
-      <div id="greeting">Hello</div>
+it('test with multiple html code blocks', () => {
+  const test = {
+    description: 'This test has multiple HTML blocks',
+    html: [
+      source`
+        <div id="greeting">Hello</div>
+      `,
+      source`
+        <div id="name">World</div>
+      `,
+    ],
+    test: source`
+      cy.get('div#greeting').should('have.text', 'Hello')
+      cy.get('div#name').should('have.text', 'World')
     `,
-    source`
-      <div id="name">World</div>
-    `,
-  ],
-  test: source`
-    cy.get('div#greeting').should('have.text', 'Hello')
-    cy.get('div#name').should('have.text', 'World')
-  `,
-}
+  }
+  cy.runExample(test)
+})
 
-it('test with markdown', () => {
+it('some html code blocks are live but hidden', () => {
+  const test = {
+    description: 'This test has multiple HTML blocks',
+    html: [
+      source`
+        <div id="greeting">Hello</div>
+      `,
+      {
+        source: source`
+          <div id="name">World</div>
+        `,
+        // do not show the source code this html block
+        // but still include it in the live html app
+        hide: true,
+      },
+    ],
+    test: source`
+      cy.get('div#greeting').should('have.text', 'Hello')
+      cy.get('div#name').should('have.text', 'World')
+      // check the HTML source shown on the page
+      // it should not show the hidden HTML code block
+      cy.get('#html')
+        .should('include.text', '<div id="greeting">Hello</div>')
+        .and('not.include.text', 'World')
+    `,
+    fullDocument: true,
+  }
   cy.runExample(test)
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="cypress" />
 
-type HTML = string
+type HTMLBlock = {
+  source: string // HTML
+  hide?: boolean
+}
+type HTML = string | HTMLBlock
 type HTMLS = HTML[]
 type JavaScript = string
 type FiddleComponent = 'html' | 'live' | 'test'


### PR DESCRIPTION
You can hide an HTML fragment to avoid including it in the HTML source shown on the page. The hidden HTML is still included in the live HTML block. Each code block must be an object with the `source` property and `hide: true|false` property.

    html: [
      source`
        <div id="greeting">Hello</div>
      `,
      {
        source: source`
          <div id="name">World</div>
        `,
        // do not show the source code this html block
        // but still include it in the live html app
        hide: true,
      },
    ]