### PR TITLE
feat: add CSS block

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,26 @@ If you have common HTML to load before the live HTML block, but do not want to s
 
 You can load styles and external CDN scripts using this approach.
 
+### CSS block
+
+You can apply CSS style to the HTML without showing it on the page
+
+```js
+const test = {
+  html: source`
+    <div id="greeting">Hello</div>
+  `,
+  css: source`
+    #greeting {
+      color: #f0f;
+      padding: 1rem;
+      font-weight: bold;
+    }
+  `,
+}
+cy.runExample(test)
+```
+
 ### Hiding fiddle in Markdown
 
 You can "hide" fiddle inside Markdown so the page _can test itself_. See [cypress/integration/hidden-fiddle.md](cypress/integration/hidden-fiddle.md) example.

--- a/cypress/integration/css-spec.js
+++ b/cypress/integration/css-spec.js
@@ -1,0 +1,26 @@
+/// <reference types="../.." />
+import { source } from 'common-tags'
+
+it('lets you use CSS blocks', () => {
+  const test = {
+    description: 'This test has a CSS block',
+    html: source`
+      <div id="greeting">Hello</div>
+    `,
+    css: source`
+      #greeting {
+        color: #f0f;
+        padding: 1rem;
+        font-weight: bold;
+      }
+    `,
+    test: source`
+      cy.get('div#greeting').should('have.text', 'Hello')
+        .and('have.css', 'color', 'rgb(255, 0, 255)')
+      // there is no CSS block
+      cy.contains('pad' + 'ding').should('not.exist')
+    `,
+    fullDocument: true,
+  }
+  cy.runExample(test)
+})

--- a/cypress/integration/multiple-html-spec.js
+++ b/cypress/integration/multiple-html-spec.js
@@ -22,7 +22,7 @@ it('test with multiple html code blocks', () => {
 
 it('some html code blocks are live but hidden', () => {
   const test = {
-    description: 'This test has multiple HTML blocks',
+    description: 'This test has multiple HTML blocks but some are hidden',
     html: [
       source`
         <div id="greeting">Hello</div>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ type HTMLBlock = {
 }
 type HTML = string | HTMLBlock
 type HTMLS = HTML[]
+type CSS = string
 type JavaScript = string
 type FiddleComponent = 'html' | 'live' | 'test'
 
@@ -41,6 +42,7 @@ interface RunExampleOptions {
   description?: string
   meta?: string
   html?: HTML | HTMLS
+  css?: CSS
   commonHtml?: HTML
   test: JavaScript
   // skip and only are exclusive - they cannot be both set to true

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ Cypress.Commands.add('runExample', (options) => {
     meta,
     commonHtml,
     html,
+    css,
     test,
     fullDocument,
   } = options
@@ -95,6 +96,9 @@ Cypress.Commands.add('runExample', (options) => {
   let style = ''
   if (typeof fiddleOptions.style === 'string' && fiddleOptions.style) {
     style = `<style>\n${fiddleOptions.style}\n</style>`
+  }
+  if (typeof css === 'string' && css) {
+    style += '\n' + `<style>\n${css}\n</style>`
   }
 
   // really dummy way to see if the test code contains "cy.visit(...)"


### PR DESCRIPTION
You can apply CSS style to the HTML without showing it on the page

```js
const test = {
  html: source`
    <div id="greeting">Hello</div>
  `,
  css: source`
    #greeting {
      color: #f0f;
      padding: 1rem;
      font-weight: bold;
    }
  `,
}
cy.runExample(test)
```